### PR TITLE
fix the abnormal blink of ground under the dinosaur

### DIFF
--- a/src/print_player.S
+++ b/src/print_player.S
@@ -51,6 +51,8 @@ dec_h:
     mov     R24, page3
     rcall   Tx
     mov     R24, page4
+    ldi     R27, 0x80
+    or      R24, R27
     rcall   Tx
     dec     _col
     brne    loop_columns


### PR DESCRIPTION
I find that when the game is running.The ground under the dinosaur is always blink very fast.
I think it should not blink.This commit  will fix this.